### PR TITLE
Switching the primary healthcheck and hiding the boilerplate one

### DIFF
--- a/_infra/helm/Chart.yaml
+++ b/_infra/helm/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.1
+version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.2.1
+appVersion: 0.2.2

--- a/_infra/helm/templates/deployment.yaml
+++ b/_infra/helm/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
               containerPort: 8059
           readinessProbe:
             httpGet:
-              path: /v2/
+              path: /v2/info/
               port: 8059
             initialDelaySeconds: 1
             periodSeconds: 20
@@ -39,7 +39,7 @@ spec:
             timeoutSeconds: 5
           livenessProbe:
             httpGet:
-              path: /v2/
+              path: /v2/info/
               port: 8059
             initialDelaySeconds: 1
             periodSeconds: 20

--- a/config.go
+++ b/config.go
@@ -5,6 +5,6 @@ import "github.com/spf13/viper"
 func setDefaults() {
 	viper.SetDefault("unleash_uri", "http://localhost:4242/api")
 	viper.SetDefault("service_name", "ras-rm-party")
-	viper.SetDefault("port", "8081")
+	viper.SetDefault("port", "8059")
 	viper.SetDefault("app_version", "unknown")
 }

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ import (
 var wg sync.WaitGroup
 
 func hello(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-	if unleash.IsEnabled("party.api.get.hello", unleash.WithFallback(true)) {
+	if unleash.IsEnabled("party.api.get.hello", unleash.WithFallback(false)) {
 		fmt.Fprint(w, viper.GetString("service_name"))
 	} else {
 		w.WriteHeader(http.StatusMethodNotAllowed)
@@ -26,16 +26,12 @@ func hello(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 }
 
 func info(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-	if unleash.IsEnabled("party.api.get.info", unleash.WithFallback(false)) {
-		info := models.Info{
-			Name:    viper.GetString("service_name"),
-			Version: viper.GetString("app_version"),
-		}
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(info)
-	} else {
-		w.WriteHeader(http.StatusMethodNotAllowed)
+	info := models.Info{
+		Name:    viper.GetString("service_name"),
+		Version: viper.GetString("app_version"),
 	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(info)
 }
 
 func addRoutes(r *httprouter.Router) {

--- a/main_test.go
+++ b/main_test.go
@@ -35,8 +35,16 @@ func setup() {
 	addRoutes(router)
 }
 
+func turnFeatureOn(feature string) {
+	unleashStub.Enable(feature)
+	// Required to let the unleash stub poll for new settings
+	time.Sleep(time.Millisecond * 1500)
+}
+
 func TestHello(t *testing.T) {
 	setup()
+	turnFeatureOn("party.api.get.hello")
+
 	req := httptest.NewRequest("GET", "/v2/", nil)
 	router.ServeHTTP(resp, req)
 	body, _ := ioutil.ReadAll(resp.Body)
@@ -52,9 +60,6 @@ func TestHello(t *testing.T) {
 
 func TestInfo(t *testing.T) {
 	setup()
-	unleashStub.Enable("party.api.get.info")
-	// Required to let the unleash stub poll for new settings
-	time.Sleep(time.Millisecond * 1500)
 
 	req := httptest.NewRequest("GET", "/v2/info/", nil)
 	router.ServeHTTP(resp, req)


### PR DESCRIPTION
[x] Helm version updated (`_infra\helm\Chart.yaml`)

Also does a little refactoring to make it harder to miss the wait needed for testing feature flagged endpoints