### PR TITLE
Refactoring to support better use of 500

### DIFF
--- a/_infra/helm/partyv2/Chart.yaml
+++ b/_infra/helm/partyv2/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.8
+version: 0.3.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.3.8
+appVersion: 0.3.9

--- a/respondents.go
+++ b/respondents.go
@@ -124,7 +124,7 @@ func getRespondents(w http.ResponseWriter, r *http.Request, _ httprouter.Params)
 	}
 
 	if db == nil {
-		w.WriteHeader(http.StatusNotFound)
+		w.WriteHeader(http.StatusInternalServerError)
 		errorString := models.Error{
 			Error: "Database connection could not be found",
 		}
@@ -203,7 +203,7 @@ func getRespondents(w http.ResponseWriter, r *http.Request, _ httprouter.Params)
 
 	rows, err := db.Query(queryString)
 	if err != nil {
-		w.WriteHeader(http.StatusNotFound)
+		w.WriteHeader(http.StatusInternalServerError)
 		errorString := models.Error{
 			Error: "Error querying DB: " + err.Error(),
 		}
@@ -233,7 +233,7 @@ func postRespondents(w http.ResponseWriter, r *http.Request, _ httprouter.Params
 	}
 
 	if db == nil {
-		w.WriteHeader(http.StatusNotFound)
+		w.WriteHeader(http.StatusInternalServerError)
 		errorString := models.Error{
 			Error: "Database connection could not be found",
 		}
@@ -283,7 +283,7 @@ func postRespondents(w http.ResponseWriter, r *http.Request, _ httprouter.Params
 	for _, code := range postRequest.EnrolmentCodes {
 		resp, err := http.Get(viper.GetString("iac_service") + "/iacs/" + code)
 		if err != nil {
-			w.WriteHeader(http.StatusNotFound)
+			w.WriteHeader(http.StatusInternalServerError)
 			errorString := models.Error{
 				Error: "Couldn't communicate with IAC service: " + err.Error(),
 			}
@@ -318,7 +318,7 @@ func postRespondents(w http.ResponseWriter, r *http.Request, _ httprouter.Params
 		// Case service
 		resp, err := http.Get(viper.GetString("case_service") + "/cases/" + enrolment.IAC.CaseID)
 		if err != nil {
-			w.WriteHeader(http.StatusNotFound)
+			w.WriteHeader(http.StatusInternalServerError)
 			errorString := models.Error{
 				Error: "Couldn't communicate with Case service: " + err.Error(),
 			}
@@ -342,7 +342,7 @@ func postRespondents(w http.ResponseWriter, r *http.Request, _ httprouter.Params
 		// Collection Exercise service
 		resp, err = http.Get(viper.GetString("collection_exercise_service") + "/collectionexercises/" + enrolment.Case.CaseGroup.CollectionExerciseID)
 		if err != nil {
-			w.WriteHeader(http.StatusNotFound)
+			w.WriteHeader(http.StatusInternalServerError)
 			errorString := models.Error{
 				Error: "Couldn't communicate with Collection Exercise service: " + err.Error(),
 			}
@@ -368,7 +368,7 @@ func postRespondents(w http.ResponseWriter, r *http.Request, _ httprouter.Params
 	defer businessQuery.Close()
 	rows, err := businessQuery.Query(pq.Array(businessIDs))
 	if err != nil {
-		w.WriteHeader(http.StatusNotFound)
+		w.WriteHeader(http.StatusInternalServerError)
 		errorString := models.Error{
 			Error: "Error querying DB: " + err.Error(),
 		}
@@ -388,7 +388,7 @@ func postRespondents(w http.ResponseWriter, r *http.Request, _ httprouter.Params
 
 	tx, err := db.Begin()
 	if err != nil {
-		w.WriteHeader(http.StatusNotFound)
+		w.WriteHeader(http.StatusInternalServerError)
 		errorString := models.Error{
 			Error: "Error creating DB transaction: " + err.Error(),
 		}
@@ -398,7 +398,7 @@ func postRespondents(w http.ResponseWriter, r *http.Request, _ httprouter.Params
 
 	insertRespondent, err := tx.Prepare("INSERT INTO partysvc.respondent (id, status, email_address, first_name, last_name, telephone, created_on) VALUES ($1,$2,$3,$4,$5,$6,$7)")
 	if err != nil {
-		w.WriteHeader(http.StatusNotFound)
+		w.WriteHeader(http.StatusInternalServerError)
 		errorString := models.Error{
 			Error: "Error creating DB prepared statement: " + err.Error(),
 		}
@@ -425,7 +425,7 @@ func postRespondents(w http.ResponseWriter, r *http.Request, _ httprouter.Params
 
 	insertBusinessRespondent, err := tx.Prepare(pq.CopyIn("partysvc.respondent", "business_id", "respondent_id", "status", "effective_from", "created_on"))
 	if err != nil {
-		w.WriteHeader(http.StatusNotFound)
+		w.WriteHeader(http.StatusInternalServerError)
 		errorString := models.Error{
 			Error: "Error creating DB prepared statement: " + err.Error(),
 		}

--- a/swagger2.yaml
+++ b/swagger2.yaml
@@ -160,6 +160,8 @@ paths:
           description: A provided enrolment code couldn't be found.
         '422':
           description: A provided enrolment code has expired or the business associated with an enrolment code couldn't be associated with.
+        '500':
+          $ref: '#/components/responses/CommunicationError'
   /respondents/{id}:
     delete:
       summary: Deletes a respondent from the service.

--- a/swagger2.yaml
+++ b/swagger2.yaml
@@ -116,6 +116,8 @@ paths:
           $ref: '#/components/responses/UnauthorizedError'
         '404':
           description: No respondents were found based on the parameters provided.
+        '500':
+          $ref: '#/components/responses/CommunicationError'
     post:
       summary: Creates a new respondent.
       description: | 
@@ -457,7 +459,7 @@ components:
           schema:
             type: object
             properties:
-              description:
+              error:
                 type: string
                 example: Respondent does not exist
     BusinessNotFoundError:
@@ -467,9 +469,19 @@ components:
           schema:
             type: object
             properties:
-              description:
+              error:
                 type: string
                 example: Business does not exist
+    CommuinicationError:
+      description: There were problems communicating with another service or the database.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+                example: "Couldn't communicate with Case service: 404 not found"
     QueryParametersMissingError:
       description: No query parameters were provided.
     InvalidRequestBodyError:


### PR DESCRIPTION
[x] Helm version updated (`_infra\helm\Chart.yaml`)

Up until now I'd been completely avoiding 500s because we were so overly reliant on them in other services. This reintroduces them where appropriate